### PR TITLE
Fix test of src/comment/comment.service.spec.ts

### DIFF
--- a/apps/backend/src/comment/comment.service.spec.ts
+++ b/apps/backend/src/comment/comment.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { CommentService } from './comment.service';
 import { CommentRepository } from './comment.repository';
 import { getRepositoryToken } from '@nestjs/typeorm';
@@ -10,11 +11,18 @@ describe('CommentService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [TypeOrmModule.forFeature([Comment])],
       providers: [
         CommentService,
         {
           provide: getRepositoryToken(Comment),
-          useClass: CommentRepository,
+          useValue: {
+            save: jest.fn(),
+            find: jest.fn(),
+            findOne: jest.fn(),
+            update: jest.fn(),
+            delete: jest.fn(),
+          },
         },
       ],
     }).compile();


### PR DESCRIPTION
Fix the test of `apps/backend/src/comment/comment.service.spec.ts` to resolve the dependency of the `CommentService` with the `CommentRepository`.

* Add `TypeOrmModule` to the imports array in the `Test.createTestingModule` call.
* Replace the `useClass` with `useValue` for the `CommentRepository` provider.
* Mock the `CommentRepository` methods using `jest.fn()`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/project-jarak/nx-jarak/pull/5?shareId=689d5d7c-5521-4e4c-b144-f73d6696f070).